### PR TITLE
Manage sizeOverlay listener lifecycle

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,6 +59,7 @@
     cooldownMs: 5000,
     scanTimer: null,
     scanning: false,
+    sizeOverlayHandler: null,
     lastScanAt: 0,
     rows: [],
     seen: {}, // key -> count
@@ -209,7 +210,10 @@
       state.scanning = true;
       sizeOverlay();
       video.addEventListener('loadedmetadata', sizeOverlayOnce, { once: true });
-      video.addEventListener('playing', sizeOverlay);
+      if(!state.sizeOverlayHandler){
+        state.sizeOverlayHandler = sizeOverlay;
+        video.addEventListener('playing', state.sizeOverlayHandler);
+      }
       setupFocusUI();
       scanLoopSchedule(100);
     })['catch'](function(err){
@@ -221,6 +225,10 @@
 
   function stopStream(){
     if(state.scanTimer){ clearTimeout(state.scanTimer); state.scanTimer = null; }
+    if(state.sizeOverlayHandler){
+      video.removeEventListener('playing', sizeOverlay);
+      state.sizeOverlayHandler = null;
+    }
     if(state.stream){ state.stream.getTracks().forEach(function(t){ t.stop(); }); }
     state.stream = null; state.track = null; state.scanning = false;
   }


### PR DESCRIPTION
## Summary
- track sizeOverlay handler in state and add it only once when starting camera stream
- remove sizeOverlay playing listener when stopping stream

## Testing
- `node --check app.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc9ccf0c832c806945aed4b31ac8