### PR TITLE
Cleanup old caches before service worker activation

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -27,7 +27,13 @@ self.addEventListener('install', (e)=>{
 });
 
 self.addEventListener('activate', (e)=>{
-  e.waitUntil(self.clients.claim());
+  e.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys.filter(k => k !== CACHE).map(k => caches.delete(k))
+    );
+    await self.clients.claim();
+  })());
 });
 
 self.addEventListener('fetch', (e)=>{


### PR DESCRIPTION
## Summary
- delete outdated caches during service worker activation

## Testing
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68afdca157e8832c804e0a73e4cd9244